### PR TITLE
Set  concurrency_hint for for asio io_services.

### DIFF
--- a/src/commonpp/thread/ThreadPool.cpp
+++ b/src/commonpp/thread/ThreadPool.cpp
@@ -51,9 +51,10 @@ ThreadPool::ThreadPool(size_t nb_thread, std::string name, size_t nb_services)
 
     services_.reserve(nb_services);
     works_.reserve(nb_services);
-    std::generate_n(std::back_inserter(services_), nb_services, []
+    const std::size_t concurrency_hint = nb_thread / nb_services;
+    std::generate_n(std::back_inserter(services_), nb_services, [concurrency_hint]
                     {
-                        return std::make_shared<boost::asio::io_service>();
+                        return std::make_shared<boost::asio::io_service>(concurrency_hint);
                     });
    }
 


### PR DESCRIPTION
If concurrency_hint is 1, asio will avoid using certain locks during runtime.
