### PR TITLE
Add bodyAppend() and change body() to not append data

### DIFF
--- a/include/commonpp/net/http/Request.hpp
+++ b/include/commonpp/net/http/Request.hpp
@@ -87,11 +87,31 @@ public:
     }
 
     template <typename Iterator>
-    Request& body(Iterator begin, Iterator end)
+    Request& bodyAppend(Iterator begin, Iterator end)
     {
         auto distance = std::distance(begin, end);
         body_.reserve(body_.size() + distance);
         body_.insert(std::end(body_), begin, end);
+        return *this;
+    }
+
+    template <typename T>
+    Request& bodyAppend(const T& t)
+    {
+        return bodyAppend(std::begin(t), std::end(t));
+    }
+
+    Request& bodyAppend(const char *str)
+    {
+        auto begin = str;
+        auto end = str + ::strlen(str);
+        return bodyAppend(begin, end);
+    }
+
+    template <typename Iterator>
+    Request& body(Iterator begin, Iterator end)
+    {
+        body_.assign(begin, end);
         return *this;
     }
 

--- a/include/commonpp/net/http/Request.hpp
+++ b/include/commonpp/net/http/Request.hpp
@@ -98,7 +98,10 @@ public:
     template <typename T>
     Request& bodyAppend(const T& t)
     {
-        return bodyAppend(std::begin(t), std::end(t));
+        using std::begin;
+        using std::end;
+
+        return bodyAppend(begin(t), end(t));
     }
 
     Request& bodyAppend(const char *str)
@@ -118,7 +121,10 @@ public:
     template <typename T>
     Request& body(const T& t)
     {
-        return body(std::begin(t), std::end(t));
+        using std::begin;
+        using std::end;
+
+        return body(begin(t), end(t));
     }
 
     Request& body(const char* str)


### PR DESCRIPTION
As discussed, memory graphs in massif look normal now.
