### PR TITLE
Make SharedCounter::sum public

### DIFF
--- a/include/commonpp/metric/type/Counter.hpp
+++ b/include/commonpp/metric/type/Counter.hpp
@@ -91,7 +91,6 @@ public:
 
     void reset();
 
-private:
     uintmax_t sum() const;
 
 private:


### PR DESCRIPTION
This is so I can make use of the SharedCounter in a Gauge adapter to avoid the problem we have with InfluxDB not supporting integration over time.  This allows me to send raw counter data, and use the derivate in grafana to get event rates etc. 
