### PR TITLE
Allow the TimeScope class to optinally set its starting time.

### DIFF
--- a/include/commonpp/metric/type/TimeScope.hpp
+++ b/include/commonpp/metric/type/TimeScope.hpp
@@ -24,8 +24,9 @@ template <typename Reservoir, typename Precision = std::chrono::microseconds>
 class TimeScope
 {
 public:
-    TimeScope(Reservoir& r)
+    TimeScope(Reservoir& r, Clock::time_point start = Clock::now())
     : reservoir_(r)
+    , start_(start)
     {
     }
 
@@ -46,7 +47,7 @@ public:
 
 private:
     Reservoir& reservoir_;
-    const Clock::time_point start_ = Clock::now();
+    const Clock::time_point start_;
     bool drop_ = false;
 };
 


### PR DESCRIPTION
for example, this allows me to use the TimeScope to measure total response time in HTTPP, by setting the start time to the actual recv'd time of the request, not just the processing time.