### PR TITLE
Port commonpp to Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,13 @@ cmake_minimum_required(VERSION 2.8)
 
 CMAKE_POLICY(SET CMP0005 NEW)
 
+# Require at least Windows 7
+# See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa383745(v=vs.85).aspx
+if(WIN32)
+    add_definitions(-D_WIN32_WINNT=0x0601)
+    add_definitions(-DNTDDI_VERSION=0x06010000)
+endif()
+
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     message(STATUS "Setting cmake build type to 'Debug' as none was specified.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,9 @@ check_have_thread_local_specifier(HAVE_THREAD_LOCAL_SPECIFIER)
 #Thread
 find_package(Threads REQUIRED)
 find_package(TBB REQUIRED)
-include_directories(${TBB_include_DIRS})
+include_directories(${TBB_INCLUDE_DIRS})
+link_directories(${TBB_LIBRARY_DIRS})
+link_directories(${TBB_DEBUG_LIBRARY_DIRS})
 
 find_package(HWLOC)
 if (HWLOC_FOUND)
@@ -160,6 +162,7 @@ endif()
 
 if (${HAVE_HWLOC})
     set (COMMONPP_DEPS ${COMMONPP_DEPS} ${HWLOC_LIBRARY})
+    include_directories(${HWLOC_INCLUDE_DIR})
 endif()
 
 add_subdirectory(include/)

--- a/bench/shared_counter/main.cpp
+++ b/bench/shared_counter/main.cpp
@@ -9,6 +9,14 @@
  *
  */
 
+#ifdef WIN32
+// Make sure boost asio is included before windows header.
+// Otherwise we will get the following error:
+// "error:  WinSock.h has already been included"
+#include <boost/asio.hpp>
+#include <windows.h>
+#endif
+
 #include <iostream>
 #include <commonpp/metric/type/Counter.hpp>
 #include <commonpp/thread/ThreadPool.hpp>

--- a/include/commonpp/core/Options.hpp
+++ b/include/commonpp/core/Options.hpp
@@ -134,12 +134,12 @@ private:
 #define COMMONPP_DECLARE_OPTIONS_OSTREAM_OP(Options)                           \
     std::ostream& operator<<(std::ostream& os, const Options& opt)
 
-#define COMMONPP_GENERATE_OPTIONS_OSTREAM_OP(Options, Enum...)                 \
+#define COMMONPP_GENERATE_OPTIONS_OSTREAM_OP(Options, ...)                     \
     COMMONPP_DECLARE_OPTIONS_OSTREAM_OP(Options)                               \
     {                                                                          \
         os << BOOST_PP_STRINGIZE(Options) << ": [";                            \
         BOOST_PP_SEQ_FOR_EACH(COMMONPP_PRINT_OPTION_IF, opt,                   \
-                              BOOST_PP_VARIADIC_TO_SEQ(Enum))                  \
+                              BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))           \
         os << "]";                                                             \
         return os;                                                             \
     }

--- a/include/commonpp/metric/MetricValue.hpp
+++ b/include/commonpp/metric/MetricValue.hpp
@@ -54,7 +54,7 @@ public:
 private:
     bool has_values() const
     {
-        return not empty();
+        return !empty();
     }
 
     template <typename T>

--- a/src/commonpp/core/string_date.cpp
+++ b/src/commonpp/core/string_date.cpp
@@ -10,6 +10,7 @@
  */
 #include "commonpp/core/string/date.hpp"
 
+#include <ctime>
 #include <sstream>
 
 namespace commonpp
@@ -22,11 +23,14 @@ std::string get_current_date()
     std::ostringstream out;
 
     std::tm tm;
-    ::gmtime_r(&current_time, &tm);
+#ifdef WIN32
+	_gmtime64_s(&tm, &current_time);
+#else
+	::gmtime_r(&current_time, &tm);
+#endif
 
     char buff[64] = {0};
     auto size = std::strftime(buff, sizeof(buff), "%c %Z", &tm);
-
     return {buff, size};
 }
 
@@ -41,7 +45,11 @@ std::string get_date(std::chrono::system_clock::time_point time_point)
 
     auto sec = static_cast<time_t>(seconds.count());
     std::tm tm;
-    ::gmtime_r(&sec, &tm);
+#ifdef WIN32
+	_gmtime64_s(&tm, &sec);
+#else
+	::gmtime_r(&sec, &tm);
+#endif
 
     char buff[32] = {0};
     auto size = std::strftime(buff, sizeof(buff), "%Y-%m-%d %H:%M:%S", &tm);

--- a/src/commonpp/metric/MetricTag.cpp
+++ b/src/commonpp/metric/MetricTag.cpp
@@ -26,7 +26,7 @@ MetricTag::MetricTag(std::string name)
 MetricTag MetricTag::create(std::string measure_name) const
 {
     MetricTag tmp = *this;
-    if (not tmp.name_.empty())
+    if (!tmp.name_.empty())
     {
         tmp.name_ += "." + measure_name;
     }
@@ -44,7 +44,7 @@ MetricTag MetricTag::operator()(std::string name) const
 
 bool MetricTag::hasTags() const noexcept
 {
-    return not tags_.empty();
+    return !tags_.empty();
 }
 
 MetricTag& MetricTag::operator+=(std::initializer_list<std::string>&& t)
@@ -89,7 +89,7 @@ MetricTag MetricTag::operator+(const MetricTag& rhs) const
     MetricTag result = *this;
     result.tags_.insert(std::end(result.tags_), std::begin(rhs.tags_),
                         std::end(rhs.tags_));
-    if (not result.name_.empty())
+    if (!result.name_.empty())
     {
         result.name_ += "." + rhs.name_;
     }
@@ -132,7 +132,7 @@ const std::string& MetricTag::toGraphiteFormat(const std::string& prefix) const
     }
 
     graphite_ = prefix;
-    if (not(graphite_.empty() || boost::ends_with(graphite_, ".")))
+    if (!(graphite_.empty() || boost::ends_with(graphite_, ".")))
     {
         graphite_ += ".";
     }
@@ -142,7 +142,7 @@ const std::string& MetricTag::toGraphiteFormat(const std::string& prefix) const
         graphite_ += sanitize_graphite(tag.second) + ".";
     }
 
-    if (not name_.empty()) // We want to keep the dots
+    if (!name_.empty()) // We want to keep the dots
     {
         graphite_ += name_;
     }

--- a/src/commonpp/metric/MetricValue.cpp
+++ b/src/commonpp/metric/MetricValue.cpp
@@ -146,19 +146,19 @@ static std::ostream& operator<<(std::ostream& os,
 
 std::ostream& operator<<(std::ostream& os, const MetricValue& value)
 {
-    if (not value.doubles_.empty())
+    if (!value.doubles_.empty())
     {
         os << "doubles: {" << value.doubles_ << "}, ";
     }
-    if (not value.integers_.empty())
+    if (!value.integers_.empty())
     {
         os << "integers: {" << value.integers_ << "}, ";
     }
-    if (not value.booleans_.empty())
+    if (!value.booleans_.empty())
     {
         os << "booleans: {" << value.booleans_ << "}, ";
     }
-    if (not value.strings_.empty())
+    if (!value.strings_.empty())
     {
         os << "strings: {" << value.strings_ << "}, ";
     }
@@ -283,7 +283,7 @@ std::string MetricValue::toGraphiteFormat(const MetricTag& tag,
 {
     std::string result;
 
-    if (not strings_.empty())
+    if (!strings_.empty())
     {
         LOG(mv_logger, warning)
             << "Strings metrics cannot be represented in graphite format.";

--- a/src/commonpp/metric/Metrics.cpp
+++ b/src/commonpp/metric/Metrics.cpp
@@ -71,7 +71,7 @@ void Metrics::calculate_metrics()
     for (const auto& counter : counters_)
     {
         auto values = counter.second();
-        if (not values.empty())
+        if (!values.empty())
         {
             metrics.emplace_back(std::cref(counter.first), std::move(values));
         }

--- a/src/commonpp/metric/sink/InfluxDB.cpp
+++ b/src/commonpp/metric/sink/InfluxDB.cpp
@@ -134,7 +134,7 @@ void InfluxDB::operator()(const Metrics::MetricVector& values)
                 boost::asio::buffer(data.data() + current_offset, BUFSIZ));
             current_offset += read_data;
             data.resize(current_offset);
-        } while (not net::http::Response::isCompleteHeader(data));
+        } while (!net::http::Response::isCompleteHeader(data));
 
         auto response = net::http::Response::from(std::move(data));
         if (response.code() != 204)

--- a/src/commonpp/net/http/Request.cpp
+++ b/src/commonpp/net/http/Request.cpp
@@ -80,7 +80,7 @@ std::vector<char> Request::buildRequest() const
 
     buffer << method_ << " " << path_;
 
-    if (not query_.empty())
+    if (!query_.empty())
     {
         buffer << "?" << query_;
     }
@@ -88,7 +88,7 @@ std::vector<char> Request::buildRequest() const
     buffer << " HTTP/" << major_ << "." << minor_ << EOL;
     buffer << headers_;
 
-    if (not body_.empty())
+    if (!body_.empty())
     {
         buffer << "Content-Length: " << string::stringify(body_.size()) << EOL
                << EOL << body_;

--- a/src/commonpp/thread/Thread.cpp
+++ b/src/commonpp/thread/Thread.cpp
@@ -29,14 +29,13 @@
 # include <boost/thread/tss.hpp>
 #endif
 
+#include "detail/logger.hpp"
 #include "commonpp/core/LoggingInterface.hpp"
 
 namespace commonpp
 {
 namespace thread
 {
-
-CREATE_LOGGER(thread_logger, "commonpp::thread");
 
 #if HAVE_THREAD_LOCAL_SPECIFIER
 static thread_local std::string current_name;

--- a/src/commonpp/thread/ThreadPool.cpp
+++ b/src/commonpp/thread/ThreadPool.cpp
@@ -28,8 +28,6 @@ namespace commonpp
 namespace thread
 {
 
-DECLARE_LOGGER(thread_logger, "commonpp::thread");
-
 namespace detail
 {
 template <ThreadPool::ThreadDispatchPolicy T>

--- a/src/commonpp/thread/detail/CMakeLists.txt
+++ b/src/commonpp/thread/detail/CMakeLists.txt
@@ -16,4 +16,5 @@ endif()
 add_commonpp_library_source(
     SOURCES
         Core.cpp
-        Cores.cpp)
+        Cores.cpp
+        logger.cpp)

--- a/src/commonpp/thread/detail/logger.cpp
+++ b/src/commonpp/thread/detail/logger.cpp
@@ -1,0 +1,22 @@
+/*
+* File: src/commonpp/thread/detail/logger.hpp
+* Part of commonpp.
+*
+* Distributed under the 2-clause BSD licence (See LICENCE.TXT file at the
+* project root).
+*
+* Copyright (c) 2016 Thomas Sanchez.  All rights reserved.
+*
+*/
+
+#include "logger.hpp"
+
+namespace commonpp
+{
+namespace thread
+{
+
+DECLARE_LOGGER(thread_logger, "commonpp::thread");
+
+} // namespace thread
+} // namespace commonpp


### PR DESCRIPTION
Works for me™ ;)

Versions I am using:
* Visual Studio 2017 Community Edition (built 64bit only)
* Boost 1.62.0 (from https://boost.teeks99.com/bin/1.62.0/boost_1_62_0-msvc-14.0-64.exe)
* Intel TBB 2017 Update 7 (https://github.com/01org/tbb/releases/download/2017_U7/tbb2017_20170604oss_win.zip)
* hwloc 1.11.7 (from https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-win64-build-1.11.7.zip)
* OpenSSL 1.0.2k (from https://www.conan.io/source/OpenSSL/1.0.2k/lasote/stable)
* libcurl 7.50.3 (from https://conan.io/source/libcurl/7.50.3/lasote/stable)

The TBB and HWLOC downloads include shared libs only. Did not try to used the ones from conan.io as well (see https://conan.io/source/hwloc/1.11.1/lasote/stable and https://www.conan.io/source/TBB/4.4.4/memsharded/testing). Maybe they allow static linking. Apart from that, all the other libraries were linked statically.

Here is the output of depends for the `shared_counter_bench.exe`:
![image](https://user-images.githubusercontent.com/176090/29252397-92b3fa44-8066-11e7-8d02-80d5dcaefded.png)

Examples and tests are also running:
```

1>------ Build started: Project: RUN_TESTS, Configuration: Debug x64 ------
1>Test project C:/Users/max/Development/commonpp/build
1>    Start 1: core_options
1>1/7 Test #1: core_options .....................   Passed    0.02 sec
1>    Start 2: core_string_stringify
1>2/7 Test #2: core_string_stringify ............   Passed    0.02 sec
1>    Start 3: core_string_encode
1>3/7 Test #3: core_string_encode ...............   Passed    0.02 sec
1>    Start 4: metric_reservoir_edr
1>4/7 Test #4: metric_reservoir_edr .............   Passed    0.25 sec
1>    Start 5: net_http_encode-decode
1>5/7 Test #5: net_http_encode-decode ...........   Passed    0.04 sec
1>    Start 6: net_http_request
1>6/7 Test #6: net_http_request .................   Passed    0.03 sec
1>    Start 7: net_http_response
1>7/7 Test #7: net_http_response ................   Passed    0.03 sec
1>
1>100% tests passed, 0 tests failed out of 7
1>
1>Total Test time (real) =   0.43 sec
========== Build: 1 succeeded, 0 failed, 1 up-to-date, 0 skipped ==========
```