### PR TITLE
Better timer reservoir

### DIFF
--- a/include/commonpp/metric/type/DescStat.hpp
+++ b/include/commonpp/metric/type/DescStat.hpp
@@ -100,7 +100,13 @@ public:
         result.push(mean(acc), "mean");
         result.push(min(acc), "min");
         result.push(max(acc), "max");
-        result.push(variance(acc), "variance");
+        {
+            auto var = variance(acc);
+            if(var >= 0)
+            {
+                result.push(::sqrt(var), "stdev");
+            }
+        }
 
         result.push(tail_quantile(acc, bacc::quantile_probability = 0.50),
                     "median");
@@ -138,7 +144,13 @@ public:
         result.push(weighted_mean(acc), "mean");
         result.push(min(acc), "min");
         result.push(max(acc), "max");
-        result.push(weighted_variance(acc), "variance");
+        {
+            auto var = weighted_variance(acc);
+            if(var >= 0)
+            {
+                result.push(::sqrt(var), "stdev");
+            }
+        }
         result.push(weighted_tail_quantile(acc, bacc::quantile_probability = 0.50), "median");
         result.push(weighted_tail_quantile(acc, bacc::quantile_probability = 0.75), "p75");
         result.push(weighted_tail_quantile(acc, bacc::quantile_probability = 0.95), "p95");

--- a/tests/metrics/reservoir/edr.cpp
+++ b/tests/metrics/reservoir/edr.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(long_period_of_inactivity_should_not_corrupt_sampling_rate)
     reservoir.pushValue(2000);
     {
         auto values = extract_values(reservoir);
-        BOOST_CHECK_EQUAL(values.size(), 2);
+        BOOST_CHECK_EQUAL(values.size(), 10);
         for (auto v : values)
         {
             BOOST_CHECK(v >= 1000 && v <= 3000);


### PR DESCRIPTION
* standard deviation instead of variance
* better data structure that allows re-scaling without copying and faster inserts
* optimized alpha for regular metrics update every 10s
* use mutex::try_lock for better parallelism