### PR TITLE
Fix missing include and macro warnings on g++7.2

### DIFF
--- a/include/commonpp/net/http/Request.hpp
+++ b/include/commonpp/net/http/Request.hpp
@@ -21,6 +21,13 @@
 #include <commonpp/core/LoggingInterface.hpp>
 #include "detail/validators.hpp"
 
+// Undefine the following macros that are defined in <sys/sysmacros.h>
+// and make g++7 complain.
+#pragma push_macro("minor")
+#undef minor
+#pragma push_macro("major")
+#undef major
+
 namespace commonpp
 {
 namespace net
@@ -163,6 +170,9 @@ private:
     Headers headers_;
     std::vector<char> body_;
 };
+
+#pragma pop_macro("major")
+#pragma pop_macro("minor")
 
 } // namespace http
 } // namespace net

--- a/src/commonpp/net/http/Response.cpp
+++ b/src/commonpp/net/http/Response.cpp
@@ -12,6 +12,7 @@
 #include "commonpp/net/http/Response.hpp"
 #include <cstdlib>
 #include <sstream>
+#include <functional>
 
 namespace commonpp
 {


### PR DESCRIPTION
I tried compiling with g++7.2 on Ubuntu 17.10 and got an error due to missing <functional> header, as well as some warnings about the minor/major macros being defined in a C header.